### PR TITLE
given_directory 'a/b/c' should point to 'a' instead of 'c'

### DIFF
--- a/lib/given_filesystem.rb
+++ b/lib/given_filesystem.rb
@@ -35,16 +35,19 @@ class GivenFilesystem
     end
   end
 
-  def directory dir_name = nil
+  def directory user_provided_directory = nil
     create_random_base_path unless path_has_base?
 
-    @path_elements.push dir_name || random_name
+    directory_to_create = user_provided_directory || random_name
+
+    @path_elements.push directory_to_create
 
     created_path = path
     FileUtils.mkdir_p created_path
     yield if block_given?
     @path_elements.pop
-    created_path
+
+    File.join path, first_segment_of_path(directory_to_create)
   end
   
   def directory_from_data to, from = nil
@@ -109,5 +112,9 @@ class GivenFilesystem
   
   def test_data_path name
     File.expand_path('spec/data/' + name)
+  end
+
+  def first_segment_of_path path
+    path.split(File::SEPARATOR).reject(&:empty?).first
   end
 end

--- a/spec/given_filesystem_spec.rb
+++ b/spec/given_filesystem_spec.rb
@@ -40,7 +40,7 @@ describe GivenFilesystem do
     deep_path = @given.directory "x/y/z"
     expect( File.exists? deep_path ).to be(true)
     expect( File.directory? deep_path ).to be(true)
-    expect( deep_path.split("/").count ).to eq path.split("/").count + 2
+    expect( deep_path.split("/").count ).to eq path.split("/").count
   end
 
   it "creates file" do

--- a/spec/given_filesystem_spec_helpers_spec.rb
+++ b/spec/given_filesystem_spec_helpers_spec.rb
@@ -56,6 +56,11 @@ describe GivenFilesystemSpecHelpers do
         expect( path ).to match /\/hello$/
       end
 
+      it "creates entire directory structure" do
+        path = given_directory "some/directory/structure"
+        expect( path ).to match /\/some$/
+      end
+
       it "creates nested directory" do
         path = nil
         given_directory "hello" do


### PR DESCRIPTION
The [intened / documented behaviour](https://github.com/cornelius/given_filesystem#using-directory-structures-in-name-parameters) is different from the actual.

This patch fixes the actual behaviour, `given_directory 'a/b/c'` will now point to 'a' (instead of 'c'), but this is a breaking change to the interface of the gem.

As the documented version is the preferred one, please consider merging it.

Thanks,
Balazs